### PR TITLE
Set link to required source filein README

### DIFF
--- a/microbit/Fan_Controller/Readme.md
+++ b/microbit/Fan_Controller/Readme.md
@@ -14,7 +14,7 @@ Das folgende Diagramm zeigt den Aufbau der dazugehörigen Schaltung.
 
 ### Code
 
-FanController.js enthält das JavaScript für den [Microsoft Block Editor](https://makecode.microbit.org/)
+Die Datei [microbit-fancontroller.js](src/microbit-fancontroller.js) enthält das JavaScript für den [Microsoft Block Editor](https://makecode.microbit.org/)
 
 Die eigentliche Steuerung der Motorgeschwindigkeit passiert in der Funktion `spinUp()` mittels:
 ```


### PR DESCRIPTION
The sourcecodefile FanController.js is currently mentioned in the README. 
I have corrected the filename (it is actually microbit-fancontroller.js) and set a link